### PR TITLE
Reading from a capture + fixed NetworkDataContainerMessage

### DIFF
--- a/labot/data/msg.py
+++ b/labot/data/msg.py
@@ -1,5 +1,5 @@
-from .binrw import Data
-from .. import protocol
+from data.binrw import Data
+import protocol
 
 
 class Msg:
@@ -30,7 +30,12 @@ class Msg:
             buf.pos = 0
             return None
         else:
-            buf.end()
+            try:
+                buf.end()
+                # This wil fail if the buffer comes from 
+                # a decompressed NetworkDataContainerMessage
+            except TypeError:
+                pass
             return Msg(id, data, count)
 
     def lenlenData(self):

--- a/labot/protocol.py
+++ b/labot/protocol.py
@@ -1,7 +1,8 @@
 from functools import reduce
 
-from .protocolBuilder import types, msg_from_id, types_from_id, primitives
-from .data import Data
+from protocolBuilder import types, msg_from_id, types_from_id, primitives
+from data import Data, Buffer
+from zlib import decompress
 
 primitives = {
     name: (
@@ -54,6 +55,13 @@ def read(type, data):
             ans[var['name']] = readVec(var, data)
         else:
             ans[var['name']] = read(var['type'], data)
+    if type['name'] == "NetworkDataContainerMessage":
+        from data import Msg  # Ugly but otherwise we get a circular import
+        innerdata = Buffer(ans['content'])
+        innerdata.uncompress()
+        innerMsg = Msg.fromRaw(innerdata, False)
+        ans['innerpacket'] = read(innerMsg.msgType, innerMsg.data)
+        print("hello")
     return ans
 
 

--- a/labot/protocolBuilder.py
+++ b/labot/protocolBuilder.py
@@ -3,9 +3,11 @@ import re
 import pickle
 
 from pprint import pprint
+from typing import Union
 
 class_pattern =\
-    r"\s*public class (?P<name>\w+) (?:extends (?P<parent>\w+) )?implements (?P<interface>\w+)\n"
+    r"\s*public class (?P<name>\w+) (?:extends (?P<parent>\w+) )?implements (?P<interface>\w+(?:, \w+)?)\n"
+
 id_pattern =\
     r"\s*public static const protocolId:uint = (?P<id>\d+);\n"
 public_var_pattern =\
@@ -139,6 +141,7 @@ def parse(t):
 
 def build():
     for t in types.values():
+        print("Parsing: " + t['name'])
         parse(t)
 
 

--- a/labot/runsniffer.py
+++ b/labot/runsniffer.py
@@ -1,0 +1,12 @@
+import sniffer.main
+import argparse
+
+parser = argparse.ArgumentParser(
+    description='Start the sniffer either from a file or from live capture.')
+parser.add_argument('--capture', '-c', metavar='PATH', type=str,
+                    help='Path to capture file')
+args = parser.parse_args()
+if args.capture:
+    sniffer.main.main(args.capture)
+else:
+    sniffer.main.main()

--- a/labot/sniffer/main.py
+++ b/labot/sniffer/main.py
@@ -1,6 +1,20 @@
-from .network import launch_in_thread
-from . import ui
+from sniffer.network import launch_in_thread
+import sniffer.ui
+import argparse
 
 
-ui.init(launch_in_thread)
-ui.async_start()
+def main(capture_file=None):
+    sniffer.ui.init(launch_in_thread, capture_file)
+    sniffer.ui.async_start()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Start the sniffer either from a file or from live capture.')
+    parser.add_argument('--capture', '-c', metavar='PATH', type=str,
+                        help='Path to capture file')
+    args = parser.parse_args()
+    if args.capture:
+        main(args.capture)
+    else:
+        main()

--- a/labot/sniffer/ui.py
+++ b/labot/sniffer/ui.py
@@ -14,8 +14,9 @@ from wdom.themes.bootstrap3 import *
 
 
 class SnifferUI(Div):
-    def __init__(self, startfun, *args, **kwargs):
+    def __init__(self, startfun, capture_file=None, *args, **kwargs):
         self.startfun = startfun
+        self.capture_file = capture_file
         self.stopfun = None
         super().__init__(*args, **kwargs)
 
@@ -36,7 +37,8 @@ class SnifferUI(Div):
     def start(self, event):
         # TODO: display message
         if self.stopfun is None:
-            self.stopfun = self.startfun(self.msgtable.appendMsg)
+            self.stopfun = self.startfun(
+                self.msgtable.appendMsg, self.capture_file)
             self.info.textContent = 'Sniffer started'
         else:
             self.info.textContent = 'Sniffer already started'
@@ -98,9 +100,9 @@ document.register_theme(bootstrap3)
 document.add_jsfile('https://unpkg.com/sticky-table-headers')
 
 
-def init(start):
+def init(start, capture_file=None):
     global ui
-    ui = SnifferUI(start)
+    ui = SnifferUI(start, capture_file=capture_file)
     set_app(ui)
 
 
@@ -113,6 +115,7 @@ def async_start():
     loop = asyncio.get_event_loop()
     t = threading.Thread(target=loop_in_thread, args=(loop,))
     t.start()
+    t.join()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1.  It's now possible to have the sniffer read from a capture file instead of  the live interface via `python runsniffer.py --capture "path/to/capture"`.

2. Doesn't crash on NetworkDataContainerMessage, although it takes a long time to process them.