### PR TITLE
Read capture files instead of live interfaces

### DIFF
--- a/labot/runsniffer.py
+++ b/labot/runsniffer.py
@@ -1,0 +1,12 @@
+import sniffer.main
+import argparse
+
+parser = argparse.ArgumentParser(
+    description='Start the sniffer either from a file or from live capture.')
+parser.add_argument('--capture', '-c', metavar='PATH', type=str,
+                    help='Path to capture file')
+args = parser.parse_args()
+if args.capture:
+    sniffer.main.main(args.capture)
+else:
+    sniffer.main.main()

--- a/labot/runsniffer.py
+++ b/labot/runsniffer.py
@@ -6,6 +6,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument('--capture', '-c', metavar='PATH', type=str,
                     help='Path to capture file')
 args = parser.parse_args()
+
 if args.capture:
     sniffer.main.main(args.capture)
 else:

--- a/labot/sniffer/main.py
+++ b/labot/sniffer/main.py
@@ -1,11 +1,11 @@
-from sniffer.network import launch_in_thread
-import sniffer.ui
+from .network import launch_in_thread
+from . import ui
 import argparse
 
 
 def main(capture_file=None):
-    sniffer.ui.init(launch_in_thread, capture_file)
-    sniffer.ui.async_start()
+    ui.init(launch_in_thread, capture_file)
+    ui.async_start()
 
 
 if __name__ == "__main__":

--- a/labot/sniffer/main.py
+++ b/labot/sniffer/main.py
@@ -1,6 +1,20 @@
-from .network import launch_in_thread
-from . import ui
+from sniffer.network import launch_in_thread
+import sniffer.ui
+import argparse
 
 
-ui.init(launch_in_thread)
-ui.async_start()
+def main(capture_file=None):
+    sniffer.ui.init(launch_in_thread, capture_file)
+    sniffer.ui.async_start()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Start the sniffer either from a file or from live capture.')
+    parser.add_argument('--capture', '-c', metavar='PATH', type=str,
+                        help='Path to capture file')
+    args = parser.parse_args()
+    if args.capture:
+        main(args.capture)
+    else:
+        main()

--- a/labot/sniffer/network.py
+++ b/labot/sniffer/network.py
@@ -20,7 +20,7 @@ except ModuleNotFoundError:
     from scapy.all import Raw, IP, PcapReader
     from scapy.data import ETH_P_ALL, MTU
 
-from data import Buffer, Msg
+from ..data import Buffer, Msg
 
 
 def sniff(store=False, prn=None, lfilter=None,

--- a/labot/sniffer/ui.py
+++ b/labot/sniffer/ui.py
@@ -14,8 +14,9 @@ from wdom.themes.bootstrap3 import *
 
 
 class SnifferUI(Div):
-    def __init__(self, startfun, *args, **kwargs):
+    def __init__(self, startfun, capture_file=None, *args, **kwargs):
         self.startfun = startfun
+        self.capture_file = capture_file
         self.stopfun = None
         super().__init__(*args, **kwargs)
 
@@ -36,7 +37,8 @@ class SnifferUI(Div):
     def start(self, event):
         # TODO: display message
         if self.stopfun is None:
-            self.stopfun = self.startfun(self.msgtable.appendMsg)
+            self.stopfun = self.startfun(
+                self.msgtable.appendMsg, self.capture_file)
             self.info.textContent = 'Sniffer started'
         else:
             self.info.textContent = 'Sniffer already started'
@@ -98,9 +100,9 @@ document.register_theme(bootstrap3)
 document.add_jsfile('https://unpkg.com/sticky-table-headers')
 
 
-def init(start):
+def init(start, capture_file=None):
     global ui
-    ui = SnifferUI(start)
+    ui = SnifferUI(start, capture_file=capture_file)
     set_app(ui)
 
 
@@ -113,6 +115,7 @@ def async_start():
     loop = asyncio.get_event_loop()
     t = threading.Thread(target=loop_in_thread, args=(loop,))
     t.start()
+    t.join()
 
 
 if __name__ == '__main__':

--- a/labot/sniffer/ui.py
+++ b/labot/sniffer/ui.py
@@ -115,7 +115,6 @@ def async_start():
     loop = asyncio.get_event_loop()
     t = threading.Thread(target=loop_in_thread, args=(loop,))
     t.start()
-    t.join()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As requested, split up the previous pull request. 

Checks for command line argument and if present tries to read from a capture instead of sniffing a live interface.