### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Parse les Msg.
 
 ## sniffer
 
-Nécessite wdom et scapy (`pip install wdom scapy`).
+Nécessite wdom et scapy-2.4.2 (`pip install wdom scapy==2.4.2`).
 
 Lancer avec
 


### PR DESCRIPTION
Doesn't work with the latest version of scapy-2.4.3

class PcapTimeoutElapsed(Scapy_Exception): removed in version 2.4.3
https://fossies.org/diffs/scapy/2.4.2_vs_2.4.3/scapy/arch/pcapdnet.py-diff.html