### PR TITLE
change default port to 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Parse les Msg.
 
 ## sniffer
 
-Nécessite wdom et scapy (`pip install wdom scapy`).
+Nécessite wdom et scapy (`pip install wdom scapy==2.4.2`).
 
 Lancer avec
 

--- a/labot/mitm/bridge.py
+++ b/labot/mitm/bridge.py
@@ -13,6 +13,7 @@ from abc import ABC, abstractmethod
 from collections import deque
 import os
 import logging
+import time
 
 from ..data import Buffer, Msg, Dumper
 from .. import protocol
@@ -214,6 +215,7 @@ class InjectorBridgeHandler(BridgeHandler):
             if self.dumper is not None:
                 self.dumper.dump(msg)
             self.other[origin].sendall(msg.bytes())
+            time.sleep(0.005)   #add 5ms delay to avoid client bug during connection.
 
             msg = Msg.fromRaw(self.buf[origin], from_client)
 

--- a/proxifier/script.js
+++ b/proxifier/script.js
@@ -19,7 +19,7 @@ Interceptor.attach(connect_p, {
             if (i < 3) this.addr += '.';
         }
 
-        var newport = 8000;
+        var newport = 8080;
         sockaddr_p.add(2).writeByteArray([Math.floor(newport / 256), newport % 256]);
         sockaddr_p.add(4).writeByteArray([127, 0, 0, 1]);
 


### PR DESCRIPTION
default port in fritm is 8080. It is then replaced by the custom port like this :
script = SCRIPT.replace("8080", str(port))